### PR TITLE
Add qduant service

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -1,0 +1,12 @@
+# System Prompt 
+You are an expert Dev-Ops engineer, who specializes in Docker, Mongo, Sqlite, Chroma, Qduant, OpenBao.
+
+You always make a plan before executing actions.
+
+# System Prompt
+Please wait for user input.
+
+## Docker Compose
+The `docker-compose.yml` for this project defines the docker stack for babylon.
+All services should run in the `babylon` docker network.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - BAO_DEV_ROOT_TOKEN_ID=dev-token
       - BAO_DEV_LISTEN_ADDRESS=0.0.0.0:8200
       - BAO_LOG_LEVEL=info
+    networks:
+      - babylon
 
   # PostgreSQL database service.
   postgres:
@@ -24,7 +26,7 @@ services:
     restart: unless-stopped
     ports:
       # Use an environment variable for the host port.
-      - "${BABYLON_DATABASE_PORT}:5432"
+      - "${BABYLON_DATABASE_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data # Persists the database data.
     environment:
@@ -37,6 +39,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - babylon
 
   # ChromaDB vector store service.
   chroma:
@@ -47,6 +51,21 @@ services:
       - "8003:8000" # Exposes the ChromaDB API port on a less common host port.
     volumes:
       - chroma_data:/chroma/data # Persists the ChromaDB data.
+    networks:
+      - babylon
+
+  # Qdrant vector database service.
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: qdrant
+    restart: unless-stopped
+    ports:
+      - "6333:6333" # HTTP API and Dashboard
+      - "6334:6334" # gRPC API
+    volumes:
+      - qdrant_data:/qdrant/storage # Persists the Qdrant data.
+    networks:
+      - babylon
 
   # Your Gunicorn application service.
   babylon-app:
@@ -67,6 +86,8 @@ services:
         condition: service_started # Ensure ChromaDB is started, but don't wait for a healthcheck.
       mongodb:
         condition: service_started # Ensure MongoDB is started.
+      qdrant:
+        condition: service_started
     environment:
       # These environment variables link your app to the OpenBao container.
       # The hostname `openbao` is automatically resolved by Docker Compose.
@@ -79,9 +100,11 @@ services:
       - CHROMA_API_ENDPOINT=http://chroma:8000
       # Environment variables for connecting to the MongoDB service.
       - MONGO_URI=mongodb://babylon:babylonpass@mongodb:27017/datalake
-      # Your application's other environment variables go here
-      # For example:
-      # - FLASK_SECRET_KEY=...
+      # Environment variables for connecting to the Qdrant service.
+      - QDRANT_HOST=qdrant
+      - QDRANT_PORT=6333
+    networks:
+      - babylon
 
   # MongoDB service.
   mongodb:
@@ -109,10 +132,8 @@ services:
       - CHROMA_API_ENDPOINT=http://chroma:8000
       # Environment variables for connecting to the MongoDB service.
       - MONGO_URI=mongodb://mongodb:27017/
-      # Your application's other environment variables go here
-      # For example:
-      # - FLASK_SECRET_KEY=...
-
+    networks:
+      - babylon
 
 # Define volumes for persistent data.
 volumes:
@@ -120,3 +141,9 @@ volumes:
   postgres_data:
   chroma_data: # Define the new volume for ChromaDB.
   mongo_data: # Define the new volume for MongoDB.
+  qdrant_data: # Define the new volume for Qdrant.
+
+# Define the network for all services.
+networks:
+  babylon:
+    driver: bridge

--- a/test-qduant.sh
+++ b/test-qduant.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Script to verify the Qdrant service health.
+
+echo "Checking Qdrant health..."
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:6333/healthz)
+
+if [ "$RESPONSE" -eq 200 ]; then
+    echo "Qdrant is healthy (HTTP $RESPONSE)."
+    exit 0
+else
+    echo "Qdrant health check failed (HTTP $RESPONSE)."
+    exit 1
+fi


### PR DESCRIPTION
- Add `qduant` docker-compose service.
- Allow access to `http://localhost:6333/dashboard` for visualization.
- Add `Agent` prompt for agent bootstrapping.